### PR TITLE
Fix dead taker

### DIFF
--- a/example-dead-taker/dead-taker-cli.lua
+++ b/example-dead-taker/dead-taker-cli.lua
@@ -1,0 +1,15 @@
+#!/usr/bin/env tarantool
+
+local netbox = require 'net.box'
+local fiber = require 'fiber'
+local log = require 'log'
+
+local clis = {}
+for w = 1, 2 do
+	clis[w] = netbox.connect('127.0.0.1:3301')
+	fiber.create(function()
+		log.info("Received: %s %s", w, clis[w]:eval('return box.space.queue:take(60)', {}, { timeout = 65 }).payload)
+	end)
+end
+
+clis[1]:close()

--- a/example-dead-taker/dead-taker.lua
+++ b/example-dead-taker/dead-taker.lua
@@ -1,0 +1,27 @@
+#!/usr/bin/env tarantool
+
+box.cfg{ listen = '127.0.0.1:3301', wal_mode = 'none' }
+box.schema.user.grant('guest', 'super', nil, nil, { if_not_exists = true })
+box.schema.space.create('queue', { if_not_exists = true }):create_index('pri', { if_not_exists = true, parts = {1, 'string'} })
+box.space.queue:create_index('xq', { parts = { { 2, 'string' }, { 1, 'string' } }, if_not_exists = true })
+box.space.queue:create_index('runat', { parts = { { 3, 'number' }, { 1, 'string' } }, if_not_exists = true })
+
+require 'xqueue'.upgrade(box.space.queue, {
+	format = {
+		{ name = 'id',      type = 'string' },
+		{ name = 'status',  type = 'string' },
+		{ name = 'runat',   type = 'number' },
+		{ name = 'payload', type = '*'      },
+	},
+	debug = true,
+	fields = {
+		status = 'status',
+		runat  = 'runat',
+	},
+	features = {
+		id = 'uuid',
+		delayed = true,
+	},
+})
+
+require 'console'.start() os.exit(0)


### PR DESCRIPTION
The dead takers now alarms alive takers to reduce wait time for the next ready task. Read more info in commit message https://github.com/moonlibs/xqueue/commit/46744c7f4e6fd54d8de63d0494e62e67d5262c22

It is possible to replace take-* channels with fiber.cond() but it will lead to enormous fiber wakeups on high load systems