### PR TITLE
self.timeoffset fix delta value

### DIFF
--- a/xqueue.lua
+++ b/xqueue.lua
@@ -694,7 +694,8 @@ function M.upgrade(space,opts,depth)
 	self.space = space.id
 
 	function self.timeoffset(delta)
-		return clock.realtime() + tonumber(delta)
+		delta = tonumber(delta) or 0
+		return clock.realtime() + delta
 	end
 	function self.timeready(time)
 		return time < clock.realtime()


### PR DESCRIPTION
Setting delta variable to zero, when tonumber func result is nil - it gives wrong runat value in some cases