### PR TITLE
allow background fibers of xqueue survive rw-ro swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ M.upgrade(space, {
 		-- id is always taken from pk
 		status   = 'status_field_name'    | status_field_no,
 		runat    = 'runat_field_name'     | runat_field_no,
-		proirity = 'proirity_field_name'  | proirity_field_no,
+		priority = 'priority_field_name'  | priority_field_no,
 	},
 	features = {
 		id = 'auto_increment' | 'time64' | 'uuid' | 'required' | function


### PR DESCRIPTION
I've changed lifetime of all background fibers of xqueue (now it is runat and workerX). Helper method `rw_fiber_f` awaits Tarantool to become RW subscribing to `box.ctl.wait_rw` or just `fiber.sleep` with `box.info.ro` checks.

It should solve most Ops during production