### PR TITLE
Fix infinite loop in take() method when tube_channel closes (2)

### DIFF
--- a/xqueue.lua
+++ b/xqueue.lua
@@ -1503,7 +1503,7 @@ function methods:take(timeout, opts)
 		if not found then
 			local left = (now + timeout) - fiber.time()
 			if left <= 0 then goto finish end
-
+			if tube_chan and tube_chan:is_closed() then goto finish end
 			(tube_chan or xq.take_wait):get(left)
 			if box.session.storage.destroyed then goto finish end
 		end


### PR DESCRIPTION
During load testing with many `take()` and `put()` calls it was observesd that `tube_chan:has_readers()` sometimes returns `false` while other fibers are listening on this channel (0.6% of cases). When scheduler then gives control to this fiber, `tube_chan:get(left)` returns `nil` because channel is closed resulting in an infinite loop.